### PR TITLE
Stop handling the case when foo.Spec.Replicas is nil

### DIFF
--- a/controllers/foo_controller.go
+++ b/controllers/foo_controller.go
@@ -102,11 +102,7 @@ func (r *FooReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, deploy, func() error {
 
 		// set the replicas from foo.Spec
-		replicas := int32(1)
-		if foo.Spec.Replicas != nil {
-			replicas = *foo.Spec.Replicas
-		}
-		deploy.Spec.Replicas = &replicas
+		deploy.Spec.Replicas = foo.Spec.Replicas
 
 		// set a label for our deployment
 		labels := map[string]string{


### PR DESCRIPTION
Sorry for nitpicking but I believe we don't need to handle the case when `foo.Spec.Replicas` is `nil` since `foo.Spec.Replicas` [is required](https://github.com/shuheiktgw/foo-controller-kubebuilder-1/blob/21e735b233f4d45159f6ee3ad66a3ad5ee76c98b/api/v1alpha1/foo_types.go#L33) is a required field and cannot be nil 😄